### PR TITLE
Adds support for deelayed urls of http and https

### DIFF
--- a/lib/deelay/utils.rb
+++ b/lib/deelay/utils.rb
@@ -13,8 +13,9 @@ module Deelay
     raise ArgumentError, "Missing URL" if splat.empty?
 
     escaped_url = ::URI.unescape(splat)
-    url = escaped_url.sub(/^http:\//, "http://")
-    url = "http://" + url if url !~ /^http:\/\//
+    protocol = (escaped_url =~ /^https:/) ? 'https' : 'http'
+    url = escaped_url.sub(/^(http|https):\//, "#{protocol}://")
+    url = "#{protocol}://" + url if url !~ /^#{protocol}:\/\//
     url << "?" + query_string if !query_string.empty?
     return url
   end

--- a/test/test_deelay_app.rb
+++ b/test/test_deelay_app.rb
@@ -36,6 +36,12 @@ class TestDeelayApp < MiniTest::Unit::TestCase
     assert_equal 302, last_response.status
   end
 
+  def test_redirect_url_with_https
+    get "/10/https://testurl.com/path"
+    em_async_continue
+    assert_equal "https://testurl.com/path", last_response.location
+    assert_equal 302, last_response.status
+  end
 
   def test_redirect_url_with_scheme
     get "/10/http://testurl.com/path"


### PR DESCRIPTION
This PR updates the deelay lib to support urls with either http or https protocol.
