### PR TITLE
async-sinatra added to gemspec dependencies.

### DIFF
--- a/deelay.gemspec
+++ b/deelay.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.add_dependency 'async_sinatra'
 
   # s.add_development_dependency "rake"
   # s.add_runtime_dependency "rest-client"


### PR DESCRIPTION
Fixes issue where async-sinatra is not resolved when this gem is dependency of another project.

Was seeing this:

``` bash
$ deelay
/Users/lwhitaker/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- sinatra/async (LoadError)
    from /Users/lwhitaker/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/gems/deelay-0.5.2/lib/deelay/app.rb:1:in `<top (required)>'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/gems/deelay-0.5.2/lib/deelay.rb:4:in `require_relative'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/gems/deelay-0.5.2/lib/deelay.rb:4:in `<top (required)>'
    from /Users/lwhitaker/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/lwhitaker/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/gems/deelay-0.5.2/bin/deelay:2:in `<top (required)>'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/bin/deelay:23:in `load'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/bin/deelay:23:in `<main>'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/bin/ruby_executable_hooks:15:in `eval'
    from /Users/lwhitaker/.rvm/gems/ruby-2.2.5/bin/ruby_executable_hooks:15:in `<main>'
```
